### PR TITLE
fix bazel build failures caused by 5032 5247 5279

### DIFF
--- a/c7n/BUILD
+++ b/c7n/BUILD
@@ -30,7 +30,7 @@ py_library(
         ":commands",
         ":config",
         requirement("argcomplete"),
-    ]
+    ],
 )
 
 py_library(
@@ -39,16 +39,16 @@ py_library(
         "commands.py",
     ],
     deps = [
+        ":config",
         ":exceptions",
         ":policy",
-        ":schema",
-        ":utils",
-        ":config",
         ":provider",
         ":resources",
+        ":schema",
+        ":utils",
         requirement("six"),
         requirement("PyYAML"),
-    ]
+    ],
 )
 
 py_library(
@@ -58,7 +58,7 @@ py_library(
     ],
     deps = [
         ":utils",
-    ]
+    ],
 )
 
 py_library(
@@ -86,15 +86,20 @@ py_library(
 py_library(
     name = "handler",
     srcs = [
-        "handler.py"
+        "handler.py",
     ],
     deps = [
+        ":config",
         ":policy",
         ":resources",
         ":utils",
-        ":config",
         requirement("boto3"),
     ],
+)
+
+py_library(
+    name = "resource_map",
+    srcs = ["resources/resource_map.py"],
 )
 
 py_library(
@@ -105,6 +110,7 @@ py_library(
         ":credentials",
         ":log",
         ":query",
+        ":resource_map",
         requirement("botocore"),
         requirement("boto3"),
         requirement("aws_xray_sdk"),
@@ -282,6 +288,13 @@ py_library(
 )
 
 py_library(
+    name = "loader",
+    srcs = [
+        "loader.py",
+    ],
+)
+
+py_library(
     name = "lookup",
     srcs = [
         "lookup.py",
@@ -324,6 +337,7 @@ py_library(
         "testing.py",
     ],
     deps = [
+        ":loader",
         ":policy",
         ":schema",
         requirement("mock"),

--- a/c7n/version.py
+++ b/c7n/version.py
@@ -1,0 +1,3 @@
+# ignoring #5279 until fixed
+# taken from setup.py
+version = u"0.9.0-unreleased"

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -24,17 +24,18 @@ py_library(
         "common.py",
         "zpill.py",
         "test_offhours.py",
-        "test_s3.py"
+        "test_s3.py",
     ]),
     data = glob(["data/**/*"]) + [":placebo_data.zip"],
+    imports = ["../tools/c7n_gcp/."],
     deps = [
-        "//c7n:testing",
-        "//c7n:handler",
-        "//c7n:ufuncs",
-        "//c7n:reports",
-        "//c7n:commands",
         "//c7n:cli",
+        "//c7n:commands",
+        "//c7n:handler",
+        "//c7n:reports",
         "//c7n:sqsexec",
+        "//c7n:testing",
+        "//c7n:ufuncs",
         "//tools/c7n_gcp/c7n_gcp:entry",
         requirement("coverage"),
         requirement("placebo"),
@@ -51,7 +52,6 @@ py_library(
         requirement("vcrpy"),
         requirement("wrapt"),
     ],
-    imports = ["../tools/c7n_gcp/."],
 )
 
 [c7n_py_test(

--- a/tools/c7n_gcp/c7n_gcp/BUILD
+++ b/tools/c7n_gcp/c7n_gcp/BUILD
@@ -27,12 +27,18 @@ py_library(
 )
 
 py_library(
+    name = "resource_map",
+    srcs = ["resources/resource_map.py"],
+)
+
+py_library(
     name = "resources",
     srcs = glob(["resources/*.py"]),
     deps = [
         ":actions",
         ":provider",
         ":query",
+        ":resource_map",
         "//c7n:filters",
         "//c7n:utils",
         requirement("jmespath"),


### PR DESCRIPTION
https://github.com/cloud-custodian/cloud-custodian/pull/5032
https://github.com/cloud-custodian/cloud-custodian/pull/5247

Some new files (loader.py and multiple resource_map.py) have been introduced in the PRs above making the existing dependency graph incompatible with bazel rules.
Some side changes in BUILD files have been produced by the formatter in plugin.

https://github.com/cloud-custodian/cloud-custodian/pull/5279
Restoring c7n/version.py since it is required by bazel as a temporary workaround.